### PR TITLE
Super hacky quick fix for code mirror induced copy/paste issues

### DIFF
--- a/js/vendor/codemirror/lib/codemirror.js
+++ b/js/vendor/codemirror/lib/codemirror.js
@@ -9612,7 +9612,7 @@
     var oldCSS = te.style.cssText, oldWrapperCSS = input.wrapper.style.cssText;
     var wrapperBox = input.wrapper.offsetParent.getBoundingClientRect();
     input.wrapper.style.cssText = "position: static";
-    te.style.cssText = "position: absolute; width: 30px; height: 30px;\n      top: " + (e.clientY - wrapperBox.top - 5) + "px; left: " + (e.clientX - wrapperBox.left - 5) + "px;\n      z-index: 1000; background: " + (ie ? "rgba(255, 255, 255, .05)" : "transparent") + ";\n      outline: none; border-width: 0; outline: none; overflow: hidden; opacity: .05; filter: alpha(opacity=5);";
+    te.style.cssText = "position: absolute; width: 30px; height: 30px;\n      top: " + (e.clientY - wrapperBox.top - 25) + "px; left: " + (e.clientX - wrapperBox.left - 25) + "px;\n      z-index: 1000; background: " + (ie ? "rgba(255, 255, 255, .05)" : "transparent") + ";\n      outline: none; border-width: 0; outline: none; overflow: hidden; opacity: .05; filter: alpha(opacity=5);";
     var oldScrollY;
     if (webkit) { oldScrollY = window.scrollY; } // Work around Chrome issue (#2712)
     display.input.focus();


### PR DESCRIPTION
### Description

Please describe your pull request.

Fixes # copy/paste issue when using code mirror

To get the appropriate context menu for a text area, there is an on contextmenu click event handler. Codemirror blocks the default action, captures the mouse position, temporarily unhides the psuedo-textarea (transparently and not self-evidently to the end user) and attempts to position the textarea element on screen where the click originated. By than continuing the default action, the browser believes the click has been made in a true text area and shows the appropriate context menu. 

However, if you adjust the opacity on line 9615, it becomes apparent that the positioning of that element is not in line with the mouse click and thus the appropriate menu never shows. By making slight adjustments to the top and left style attributes given to the psuedo textarea element when it's shown, we can place it in the appropriate position and thus end up with the intended menu.

Signed-off-by: Jeff Bingaman <bingaman.jeff@gmail.com>

Before submitting pull request, please review the following checklist:

- [x] Make sure you have read our [CONTRIBUTING.md](https://github.com/phpmyadmin/phpmyadmin/blob/master/CONTRIBUTING.md) document.
- [x] Make sure you are making a pull request against the correct branch. For example, for bug fixes in a released version use the corresponding QA branch and for new features use the _master_ branch. If you have a doubt, you can ask as a comment in the bug report or on the mailing list.
- [x] Every commit has proper `Signed-off-by` line as described in our [DCO](https://github.com/phpmyadmin/phpmyadmin/blob/master/DCO). This ensures that the work you're submitting is your own creation.
- [x] Every commit has a descriptive commit message.
- [x] Every commit is needed on its own, if you have just minor fixes to previous commits, you can squash them.
- [x] Any new functionality is covered by tests.
